### PR TITLE
Korrektur Hyperbolische Längenmetrik

### DIFF
--- a/chapters/06_HyperbolischeEbene.tex
+++ b/chapters/06_HyperbolischeEbene.tex
@@ -192,7 +192,7 @@ Betrachte dazu die spezielle lineare Gruppe \( \text{SL}(n,\R) \), also die Meng
 \begin{definition}[Hyperbolische Längenmetrik]
   Analog zu \( \R^2 \), \( S^2 \) usw.\ definieren wir eine Längenmetrik
   \begin{equation*}
-    d_h(p,q) \coloneqq \inf \underset{\mathclap{c \in \Omega}}{L_k}(c) \ \text{ mit } \ \Omega_{pq} \coloneqq \text{stückweise db. Kurven in \( H^2 \) zwischen \( p \) und \( q \).}
+    d_h(p,q) \coloneqq \underset{c \in \Omega_{pq}}{\inf} L_h(c) \ \text{ mit } \ \Omega_{pq} \coloneqq \text{stückweise db. Kurven in \( H^2 \) zwischen \( p \) und \( q \).}
   \end{equation*}
 \end{definition}
 


### PR DESCRIPTION
Die letzte Änderung, die noch lokal bei mir rumlag.
von
![vorher](https://user-images.githubusercontent.com/2668288/38452802-a023176a-3a4b-11e8-8be7-e6355a2d1722.png)
zu
![nachher](https://user-images.githubusercontent.com/2668288/38452808-aa2399f6-3a4b-11e8-9c30-e37550cd047b.png)